### PR TITLE
fix: remove else statement in spliter

### DIFF
--- a/response-stream.go
+++ b/response-stream.go
@@ -180,7 +180,6 @@ func spliter(data []byte, atEOF bool) (advance int, token []byte, err error) {
 
 	if atEOF {
 		return size, data, bufio.ErrFinalToken
-	} else {
-		return size, data, nil
 	}
+	return size, data, nil
 }


### PR DESCRIPTION
nit: 
I assume we can remove the else statement. I am referring to the Uber go style [here](https://github.com/uber-go/guide/blob/master/style.md#reduce-nesting ): 
@miton18 